### PR TITLE
validateString should error if jsValue is array of strings

### DIFF
--- a/src/main/scala/io/flow/apidoc-json-validation/JsonValidator.scala
+++ b/src/main/scala/io/flow/apidoc-json-validation/JsonValidator.scala
@@ -205,12 +205,7 @@ case class JsonValidator(val service: Service) {
 
   def validateString(prefix: String, js: JsValue): Either[Seq[String], JsString] = {
     js match {
-      case v: JsArray => {
-        v.value.size match {
-          case 1 => validateString(prefix, v.value.head)
-          case _ => Left(Seq(s"$prefix must be a string and not an array"))
-        }
-      }
+      case v: JsArray => Left(Seq(s"$prefix must be a string and not an array"))
       case v: JsBoolean => Right(JsString(v.value.toString))
       case JsNull => Left(Seq(s"$prefix must be a string and not null"))
       case v: JsNumber => Right(JsString(v.value.toString))

--- a/src/test/scala/io/flow/apidoc-json-validation/ApidocServiceSpec.scala
+++ b/src/test/scala/io/flow/apidoc-json-validation/ApidocServiceSpec.scala
@@ -91,4 +91,20 @@ class ApidocServiceSpec extends FunSpec with Matchers {
     )
   }
 
+  it("validate form data") {
+    val jsval = Json.obj(
+      "order_number" -> Seq[String]("123"),
+      "token" -> "blah",
+      "discriminator" -> "merchant_of_record_authorization_form"
+    )
+
+    service.upcast(
+      "POST",
+      "/:organization/authorizations",
+      jsval
+    ) should equal(
+      Left(Seq("Type 'merchant_of_record_authorization_form' field 'order_number' must be a string and not an array"))
+    )
+  }
+
 }


### PR DESCRIPTION
Looks like the issue with the OV payments was related to JsonValidator not erroring when passing an array of strings to order_number rather than a string. For example, validateString is fine with either `"order_number": ["123"]` or `"order_number": "123"` because validateString sees that there's just a single value in the array, so it validates that string and it passes. This doesn't conform to the schema and fails in payment when play can't cast `"order_number": ["123"]` to order_number string as defined in the model.